### PR TITLE
Adding support for custom pool floors

### DIFF
--- a/Azure.HyperScale.ElasticPool.AutoScaler.Tests/ConfigurationTests.cs
+++ b/Azure.HyperScale.ElasticPool.AutoScaler.Tests/ConfigurationTests.cs
@@ -176,7 +176,6 @@ public class ConfigurationTests
         var configuration = LoadConfiguration(new Dictionary<string, string?> { { "ElasticPools", "ProdDbPoolHS1,ProdDbPoolHS2:8" } });
         var autoScalerConfig = new AutoScalerConfiguration(configuration);
 
-        // Assert
         Assert.Equal(2, autoScalerConfig.ElasticPools.Count);
         Assert.True(autoScalerConfig.ElasticPools.ContainsKey("ProdDbPoolHS1"));
         Assert.True(autoScalerConfig.ElasticPools.ContainsKey("ProdDbPoolHS2"));
@@ -187,13 +186,15 @@ public class ConfigurationTests
     [Fact]
     public void GetVCoreFloorForPool_ReturnsCorrectVCoreFloor()
     {
-        var configuration = LoadConfiguration(new Dictionary<string, string?> { { "ElasticPools", "ProdDbPoolHS1,ProdDbPoolHS2:8,ProdDbPoolHS3,ProdDbPoolHS4:10" } });
+        var configuration = LoadConfiguration(new Dictionary<string, string?> { {
+            "ElasticPools", "ProdDbPoolHS1,ProdDbPoolHS2:8,ProdDbPoolHS3,ProdDbPoolHS4:10" }, {
+            "VCoreFloor", "6"
+            } });
         var autoScalerConfig = new AutoScalerConfiguration(configuration);
 
-        // Act & Assert
-        Assert.Equal(4, autoScalerConfig.GetVCoreFloorForPool("ProdDbPoolHS1"));
+        Assert.Equal(6, autoScalerConfig.GetVCoreFloorForPool("ProdDbPoolHS1"));
         Assert.Equal(8, autoScalerConfig.GetVCoreFloorForPool("ProdDbPoolHS2"));
-        Assert.Equal(4, autoScalerConfig.GetVCoreFloorForPool("ProdDbPoolHS3"));
+        Assert.Equal(6, autoScalerConfig.GetVCoreFloorForPool("ProdDbPoolHS3"));
         Assert.Equal(10, autoScalerConfig.GetVCoreFloorForPool("ProdDbPoolHS4"));
     }
     [Fact]

--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ Deploy the solution to Azure and set up the application settings using the conte
 - **SubscriptionId**: The Azure subscription ID where the server lives. Needed for scaling operations.
 - **SqlInstanceName**: Name of the Azure SQL Server instance where the Elastic Pools are hosted. Needed for scaling operations.
 - **ResourceGroupName**: Name of the resource group where the Azure SQL Server is hosted. Needed for scaling operations.
-- **ElasticPools**: Comma separated list of Elastic Pools to monitor.
+- **ElasticPools**: Comma separated list of Elastic Pools to monitor. You may set a custom VCoreFloor for any given pool by adding a colon and the vCore, like `"PoolName1:8,PoolName2"`. In this case, PoolName1 will be kept at a floor of 8 vCore while PoolName2 will use the global floor.
 - **LowCpuPercent**, **HighCpuPercent**: Average CPU Percent low and high thresholds.
 - **LowWorkersPercent**, **HighWorkersPercent**: Workers Percent low and high thresholds.
 - **LowInstanceCpuPercent**, **HighInstanceCpuPercent**: SQL Instance CPU Percent low and high thresholds.


### PR DESCRIPTION
This PR is an enhancement which enables the configuration of a custom VCoreFloor for any given pool.

The custom floor must be within the bounds of the available VCoreOptions also specified in the configuration.

To use this, you'd set the value of ElasticPools to something like `"ProdDbPoolHS1,ProdDbPoolHS2:8,ProdDbPoolHS3,ProdDbPoolHS4:10"`

The custom pool floor override is optional.