### PR TITLE
chore: update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup DotNet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -34,7 +34,7 @@ jobs:
         run: dotnet publish ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }} --configuration Release --output ./publish
 
       - name: Deploy to PRODUCTION
-        uses: Azure/functions-action@v1
+        uses: Azure/functions-action@v1.5.4
         with:
           app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
           slot-name: PRODUCTION
@@ -42,7 +42,7 @@ jobs:
           package: ./publish
 
       - name: Deploy to Central US PRODUCTION Slot
-        uses: Azure/functions-action@v1
+        uses: Azure/functions-action@v1.5.4
         with:
           app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME_CENTRALUS }}
           slot-name: PRODUCTION

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup DotNet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v4 → v5 (Node.js 24)
- Update `actions/setup-dotnet` v4 → v5 (Node.js 24)
- Update `Azure/functions-action` v1 → v1.5.4 (Node.js 24)

Resolves the GitHub Actions deprecation warning: "Node.js 20 actions are deprecated" with enforcement starting June 2, 2026.

## Test plan
- [ ] Verify `build-test` workflow passes on this PR
- [ ] Merge and verify `build-test-deploy` workflow succeeds on push to main