### PR TITLE
fix: force CHECKPOINT batch parsing so pre-scale checkpoint actually runs

### DIFF
--- a/Azure.HyperScale.ElasticPool.AutoScaler/SqlRepository.cs
+++ b/Azure.HyperScale.ElasticPool.AutoScaler/SqlRepository.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Azure.Core;
 using Azure.Identity;
 using Dapper;
@@ -381,7 +382,10 @@ public class SqlRepository : ISqlRepository
                     {
                         var connStr = BuildPoolDbConnectionString(_config.PoolDbConnection, dbName);
                         await using var conn = await CreateSqlConnectionAsync(connStr);
-                        await conn.ExecuteAsync("CHECKPOINT").ConfigureAwait(false);
+                        // Dapper auto-detects single-identifier SQL as a stored-procedure name.
+                        // The terminator + explicit CommandType.Text forces batch parsing so SQL Server
+                        // executes CHECKPOINT as the T-SQL command instead of EXEC CHECKPOINT.
+                        await conn.ExecuteAsync("CHECKPOINT;", commandType: CommandType.Text).ConfigureAwait(false);
                     });
                     _logger.LogInformation("Checkpoint completed for database {Database} in pool {Pool}.",
                         dbName, elasticPoolName);

--- a/tools/checkpoint-repro/CheckpointRepro.csproj
+++ b/tools/checkpoint-repro/CheckpointRepro.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>CheckpointRepro</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+  </ItemGroup>
+</Project>

--- a/tools/checkpoint-repro/Program.cs
+++ b/tools/checkpoint-repro/Program.cs
@@ -1,0 +1,87 @@
+using System.Data;
+using Azure.Core;
+using Azure.Identity;
+using Dapper;
+using Microsoft.Data.SqlClient;
+
+var server = GetArg(args, "--server");
+var database = GetArg(args, "--database");
+
+if (server is null || database is null)
+{
+    Console.Error.WriteLine("Usage: dotnet run -- --server <fqdn> --database <name>");
+    Console.Error.WriteLine("  e.g. dotnet run -- --server ta-proddb.database.windows.net --database Admin");
+    return 2;
+}
+
+var connStr = new SqlConnectionStringBuilder
+{
+    DataSource = server,
+    InitialCatalog = database,
+    Encrypt = true,
+    TrustServerCertificate = false,
+    ConnectTimeout = 30,
+}.ConnectionString;
+
+Console.WriteLine($"Server   : {server}");
+Console.WriteLine($"Database : {database}");
+Console.WriteLine($"Dapper   : {typeof(SqlMapper).Assembly.GetName().Version}");
+Console.WriteLine($"SqlClient: {typeof(SqlConnection).Assembly.GetName().Version}");
+Console.WriteLine();
+
+Console.Write("Acquiring AAD token via DefaultAzureCredential... ");
+var cred = new DefaultAzureCredential();
+var token = await cred.GetTokenAsync(
+    new TokenRequestContext(new[] { "https://database.windows.net/.default" }));
+Console.WriteLine("done.");
+
+await using var conn = new SqlConnection(connStr) { AccessToken = token.Token };
+await conn.OpenAsync();
+var whoami = await conn.QuerySingleAsync<string>("SELECT SUSER_SNAME()");
+Console.WriteLine($"Connected as: {whoami}\n");
+
+await RunCase("A. Dapper Execute(\"CHECKPOINT\")                ", () =>
+    conn.ExecuteAsync("CHECKPOINT"));
+
+await RunCase("B. Dapper Execute(\"CHECKPOINT;\")               ", () =>
+    conn.ExecuteAsync("CHECKPOINT;"));
+
+await RunCase("C. Dapper Execute(\"CHECKPOINT\", Text)          ", () =>
+    conn.ExecuteAsync("CHECKPOINT", commandType: CommandType.Text));
+
+await RunCase("D. Dapper Execute(\"CHECKPOINT;\", Text)         ", () =>
+    conn.ExecuteAsync("CHECKPOINT;", commandType: CommandType.Text));
+
+await RunCase("E. Raw SqlCommand \"CHECKPOINT\" (Text)          ", async () =>
+{
+    await using var cmd = new SqlCommand("CHECKPOINT", conn) { CommandType = CommandType.Text };
+    await cmd.ExecuteNonQueryAsync();
+});
+
+await RunCase("F. Raw SqlCommand \"CHECKPOINT;\" (Text)         ", async () =>
+{
+    await using var cmd = new SqlCommand("CHECKPOINT;", conn) { CommandType = CommandType.Text };
+    await cmd.ExecuteNonQueryAsync();
+});
+
+return 0;
+
+static string? GetArg(string[] args, string name)
+{
+    var i = Array.IndexOf(args, name);
+    return i >= 0 && i + 1 < args.Length ? args[i + 1] : null;
+}
+
+static async Task RunCase(string label, Func<Task> action)
+{
+    try
+    {
+        await action();
+        Console.WriteLine($"{label}  PASS");
+    }
+    catch (Exception ex)
+    {
+        var first = ex.Message.Split('\n')[0].Trim();
+        Console.WriteLine($"{label}  FAIL  [{ex.GetType().Name}] {first}");
+    }
+}

--- a/tools/checkpoint-repro/README.md
+++ b/tools/checkpoint-repro/README.md
@@ -1,0 +1,31 @@
+# checkpoint-repro
+
+Live diagnostic that reproduces the Dapper single-token sproc-detection trap which caused PR #60's CHECKPOINT feature to silently fail in production (Sentry [TA-HYPERSCALE-AUTOSCALER-2M](https://datacor.sentry.io/issues/TA-HYPERSCALE-AUTOSCALER-2M)).
+
+## What it tests
+
+Six variants of the same logical operation against a real Hyperscale database, using the same Dapper + SqlClient versions as the autoscaler:
+
+| Case | Form | Expected |
+|---|---|---|
+| A | `conn.ExecuteAsync("CHECKPOINT")` | **FAIL** — Dapper auto-detects single-identifier SQL and sends it as RPC `EXEC CHECKPOINT`, which SQL Server rejects with `Could not find stored procedure 'CHECKPOINT'`. |
+| B | `conn.ExecuteAsync("CHECKPOINT;")` | PASS — terminator breaks the heuristic. |
+| C | `conn.ExecuteAsync("CHECKPOINT", commandType: CommandType.Text)` | PASS — explicit Text bypasses the heuristic. |
+| D | `conn.ExecuteAsync("CHECKPOINT;", commandType: CommandType.Text)` | PASS — current production fix (`SqlRepository.cs:384`). |
+| E | Raw `SqlCommand("CHECKPOINT")` | PASS — control showing the bug is in Dapper, not SqlClient. |
+| F | Raw `SqlCommand("CHECKPOINT;")` | PASS — control. |
+
+## Run
+
+```
+az login                       # uses lsilverman@trkabt.com or whichever identity has DB access
+cd tools/checkpoint-repro
+dotnet run -c Release -- --server <server-fqdn> --database <db-name>
+```
+
+Uses `DefaultAzureCredential`, so any of az-cli login, environment vars, or managed identity work.
+
+## When to re-run
+
+- After bumping the Dapper or Microsoft.Data.SqlClient package version, to confirm the heuristic still behaves as expected and case D still passes.
+- If Sentry shows `Could not find stored procedure 'CHECKPOINT'` again — first check this hasn't regressed at `SqlRepository.cs:384`, then re-run this to confirm the package versions haven't changed the heuristic.


### PR DESCRIPTION
## Summary

- PR #60 added a `CHECKPOINT` before each scaling operation to shorten Hyperscale crash-recovery time. We detected in production that this checkpoint had been failing on every database in every scaling run since the day it shipped.
- Root cause: Dapper auto-detects single-identifier SQL as a stored-procedure name. `conn.ExecuteAsync("CHECKPOINT")` was sent to SQL Server as `EXEC CHECKPOINT`, which fails with `Could not find stored procedure 'CHECKPOINT'`. The existing `try/catch` at `SqlRepository.cs:389-393` then let scaling proceed without the intended checkpoint.
- Fix: `ExecuteAsync("CHECKPOINT;", commandType: CommandType.Text)`. Either the terminator or the explicit `CommandType.Text` alone is enough to defeat Dapper's heuristic — both together survives a future maintainer simplifying one away.

## Verification

Reproduced and validated against a real Hyperscale database (Dapper 2.1.66, Microsoft.Data.SqlClient 6.1.4): bare `"CHECKPOINT"` fails as in production; `"CHECKPOINT;" + CommandType.Text` succeeds. The probe is preserved under `tools/checkpoint-repro/` for re-running after future Dapper / SqlClient upgrades.

This is the only single-identifier Dapper call in the codebase, so no other sites are at risk of the same trap.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 74/74 passing
- [x] Live verification against `Admin` database in a Hyperscale pool
- [ ] After deploy: confirm the `"Checkpoint completed for database {Database}"` INFO log appears for each DB in the pool during a scaling run