### PR TITLE
chore: drop Newtonsoft.Json and unused legacy / ASP.NET Core packages, bump deps

### DIFF
--- a/Azure.HyperScale.ElasticPool.AutoScaler.Tests/Azure.HyperScale.ElasticPool.AutoScaler.Tests.csproj
+++ b/Azure.HyperScale.ElasticPool.AutoScaler.Tests/Azure.HyperScale.ElasticPool.AutoScaler.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Azure.HyperScale.ElasticPool.AutoScaler/Azure.HyperScale.ElasticPool.AutoScaler.csproj
+++ b/Azure.HyperScale.ElasticPool.AutoScaler/Azure.HyperScale.ElasticPool.AutoScaler.csproj
@@ -11,16 +11,13 @@
     <None Remove="readme.md" />
   </ItemGroup>
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="azure.identity" Version="1.18.0" />
+    <PackageReference Include="azure.identity" Version="1.21.0" />
     <PackageReference Include="azure.resourcemanager" Version="1.14.0" />
-    <PackageReference Include="azure.resourcemanager.sql" Version="1.3.0" />
-    <PackageReference Include="dapper" Version="2.1.66" />
+    <PackageReference Include="azure.resourcemanager.sql" Version="1.4.0" />
+    <PackageReference Include="dapper" Version="2.1.79" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="microsoft.data.sqlclient" Version="6.1.4" />

--- a/Azure.HyperScale.ElasticPool.AutoScaler/Program.cs
+++ b/Azure.HyperScale.ElasticPool.AutoScaler/Program.cs
@@ -17,7 +17,6 @@ var host = new HostBuilder()
             config.AddUserSecrets(typeof(AutoScalerConfiguration).Assembly, optional: true);
         }
     })
-    .ConfigureFunctionsWebApplication()
     .ConfigureFunctionsWorkerDefaults((context, builder) =>
     {
         if (isSentryLoggingEnabled && !string.IsNullOrEmpty(sentryDsn))

--- a/Azure.HyperScale.ElasticPool.AutoScaler/SQL/monitor-autoscaler.sql
+++ b/Azure.HyperScale.ElasticPool.AutoScaler/SQL/monitor-autoscaler.sql
@@ -1,17 +1,17 @@
 select
     *
-from 
+from
     [hs].[AutoScalerMonitor] as m
 cross apply
     openjson(m.UsageInfo) with (
-        TimeStamp datetime,
         ElasticPoolCpuLimit int,
-        AvgCpuPercent decimal(9,3),
-        MovingAvgCpuPercent decimal(9,3),
-        WorkersPercent decimal(9,3),
-        MovingAvgWorkersPercent decimal(9,3),
-        AvgInstanceCpuPercent decimal(9,3),
-        MovingAvgInstanceCpuPercent decimal(9,3),
-        DataPoints int
+        ShortAvgCpu decimal(9,3),
+        LongAvgCpu decimal(9,3),
+        ShortInstanceCpu decimal(9,3),
+        LongInstanceCpu decimal(9,3),
+        ShortWorkersPercent decimal(9,3),
+        LongWorkersPercent decimal(9,3),
+        ShortDataIo decimal(9,3),
+        LongDataIo decimal(9,3)
     ) as u
 order by m.InsertedAt desc

--- a/Azure.HyperScale.ElasticPool.AutoScaler/SqlRepository.cs
+++ b/Azure.HyperScale.ElasticPool.AutoScaler/SqlRepository.cs
@@ -1,10 +1,10 @@
 using System.Data;
+using System.Text.Json;
 using Azure.Core;
 using Azure.Identity;
 using Dapper;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Polly;
 using Polly.Retry;
 
@@ -338,7 +338,7 @@ public class SqlRepository : ISqlRepository
                     elasticPool.ElasticPoolName,
                     CurrentSLO = currentVCore.ToString("F2"), // Format to 2 decimal places
                     RequestedSLO = targetVCore.ToString("F2"), // Format to 2 decimal places
-                    UsageInfo = JsonConvert.SerializeObject(elasticPool),
+                    UsageInfo = JsonSerializer.Serialize(elasticPool),
                     Notes = notes
                 }).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary

While reviewing dependencies, found two unused packages that were dragging in larger transitive chains.

**`Microsoft.Azure.Functions.Extensions 1.1.0`** is the legacy in-process Functions SDK. The autoscaler runs on the isolated worker model with no references to `[FunctionName]`, `FunctionsStartup`, or `IFunctionsHostBuilder` in the codebase. Removing it also drops the chain that pulled in `Microsoft.Azure.WebJobs 3.0.18` and, through it, `Newtonsoft.Json 11.0.2` (flagged High by [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr), DoS via deeply nested JSON).

**`Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore 2.1.0`**, the `Microsoft.AspNetCore.App` framework reference, and the `.ConfigureFunctionsWebApplication()` call in `Program.cs`. The autoscaler is timer-triggered only with no HTTP triggers and no ASP.NET Core types anywhere in the codebase.

The autoscaler did use Newtonsoft.Json directly in one place: serializing `UsageInfo` when writing to the optional `hs.AutoScalerMonitor` audit table. This PR migrates that call to `System.Text.Json`. The DTO contains only primitive types and has no JSON attributes, so STJ produces output that matches Newtonsoft for the current schema. The AutoScaler never reads the column back (the readme confirms it is write-only), and there are no internal consumers.

Also updated `SQL/monitor-autoscaler.sql`. Its `OPENJSON ... WITH` clause referenced property names that no longer exist on `UsageInfo`. Updated to match the current short and long window schema.

## Dependency bumps

Exercised by the existing test suite, no behavior changes expected:

| Package | Before | After |
|---|---|---|
| `azure.identity` | 1.18.0 | 1.21.0 |
| `azure.resourcemanager.sql` | 1.3.0 | 1.4.0 |
| `dapper` | 2.1.66 | 2.1.79 |
| `Microsoft.Azure.Functions.Worker` | 2.51.0 | 2.52.0 |
| `Microsoft.NET.Test.Sdk` (test-only) | 18.3.0 | 18.5.1 |

Major version bumps deferred to dedicated PRs, each warranting its own validation pass: `Microsoft.ApplicationInsights.WorkerService` 2 → 3, `microsoft.data.sqlclient` 6 → 7, `coverlet.collector` 8 → 10, and `xunit` v2 → v3.

## Verification

- [x] `dotnet build` clean
- [x] `dotnet test` 74/74 passing
- [x] `dotnet list package --vulnerable --include-transitive` reports no findings on the production assembly
- [x] Newtonsoft.Json no longer in the autoscaler's dependency graph (the test runner still pulls a safe 13.0.3 transitively, which never ships to production)
- [x] `func start` smoke test clean locally with the HTTP integration removed