### PR TITLE
chore: upgrade Azure Functions runtime to .NET 10 LTS

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1,22 +1,17 @@
 name: Build, Test, and Deploy to Azure Function App
 
-# Deploys to the 'staging' slot of both prod Function Apps.
-# Production swap is MANUAL — run this after validating staging:
+# Deploys to the 'staging' slot of each Function App.
+# Production rollout is a MANUAL `az functionapp deployment slot swap`
+# (re-run reverses the swap, providing rollback). See operator runbook
+# for region-specific names and the exact swap commands.
 #
-#   az functionapp deployment slot swap --slot staging --target-slot production \
-#     --subscription "TrackAbout CSP" --resource-group ta-prod-rg-2 --name ta-autoscaler-useast2
-#
-#   az functionapp deployment slot swap --slot staging --target-slot production \
-#     --subscription "TrackAbout CSP" --resource-group ta-prod-ceus-rg --name ta-autoscaler-uscentral
-#
-# Rollback: re-run the same swap command — it reverses the previous swap.
-#
-# Required GitHub secrets (staging publish profiles, one per region):
-#   AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING            (useast2 staging)
-#   AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING  (uscentral staging)
-# Fetch with:
+# Required GitHub secrets:
+#   AZURE_FUNCTIONAPP_NAME, AZURE_FUNCTIONAPP_NAME_CENTRALUS
+#   AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING            (region 1 staging slot)
+#   AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING  (region 2 staging slot)
+# Fetch a staging publish profile and set as a GH secret in one pipe:
 #   az functionapp deployment list-publishing-profiles --slot staging --xml \
-#     --subscription "TrackAbout CSP" --resource-group <rg> --name <app> \
+#     --subscription <SUB> --resource-group <RG> --name <APP> \
 #     | gh secret set <SECRET_NAME>
 
 on:
@@ -32,6 +27,20 @@ jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Verify required secrets are set
+        env:
+          PROFILE_USEAST2: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING }}
+          PROFILE_CENTRALUS: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING }}
+          NAME_USEAST2: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
+          NAME_CENTRALUS: ${{ secrets.AZURE_FUNCTIONAPP_NAME_CENTRALUS }}
+        run: |
+          missing=0
+          [ -z "$PROFILE_USEAST2" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING is not set"; missing=1; }
+          [ -z "$PROFILE_CENTRALUS" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING is not set"; missing=1; }
+          [ -z "$NAME_USEAST2" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_NAME is not set"; missing=1; }
+          [ -z "$NAME_CENTRALUS" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_NAME_CENTRALUS is not set"; missing=1; }
+          exit $missing
+
       - name: Checkout code
         uses: actions/checkout@v5
 
@@ -60,6 +69,24 @@ jobs:
           publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING }}
           package: ./publish
 
+      - name: Health check East US 2 staging slot
+        env:
+          APP_NAME: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
+        run: |
+          URL="https://${APP_NAME}-staging.azurewebsites.net/"
+          echo "Polling $URL for up to 180s..."
+          for i in $(seq 1 18); do
+            code=$(curl -s -o /tmp/body -w "%{http_code}" --max-time 10 "$URL" || echo "000")
+            if [ "$code" = "200" ] && grep -q "Functions" /tmp/body; then
+              echo "✓ Staging slot responding (HTTP 200, Functions placeholder present)"
+              exit 0
+            fi
+            echo "  attempt $i: code=$code"
+            sleep 10
+          done
+          echo "::error::East US 2 staging slot did not respond healthy within 180s"
+          exit 1
+
       - name: Deploy to Central US staging slot
         uses: Azure/functions-action@v1.5.4
         with:
@@ -67,3 +94,21 @@ jobs:
           slot-name: staging
           publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING }}
           package: ./publish
+
+      - name: Health check Central US staging slot
+        env:
+          APP_NAME: ${{ secrets.AZURE_FUNCTIONAPP_NAME_CENTRALUS }}
+        run: |
+          URL="https://${APP_NAME}-staging.azurewebsites.net/"
+          echo "Polling $URL for up to 180s..."
+          for i in $(seq 1 18); do
+            code=$(curl -s -o /tmp/body -w "%{http_code}" --max-time 10 "$URL" || echo "000")
+            if [ "$code" = "200" ] && grep -q "Functions" /tmp/body; then
+              echo "✓ Staging slot responding (HTTP 200, Functions placeholder present)"
+              exit 0
+            fi
+            echo "  attempt $i: code=$code"
+            sleep 10
+          done
+          echo "::error::Central US staging slot did not respond healthy within 180s"
+          exit 1

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1,5 +1,24 @@
 name: Build, Test, and Deploy to Azure Function App
 
+# Deploys to the 'staging' slot of both prod Function Apps.
+# Production swap is MANUAL — run this after validating staging:
+#
+#   az functionapp deployment slot swap --slot staging --target-slot production \
+#     --subscription "TrackAbout CSP" --resource-group ta-prod-rg-2 --name ta-autoscaler-useast2
+#
+#   az functionapp deployment slot swap --slot staging --target-slot production \
+#     --subscription "TrackAbout CSP" --resource-group ta-prod-ceus-rg --name ta-autoscaler-uscentral
+#
+# Rollback: re-run the same swap command — it reverses the previous swap.
+#
+# Required GitHub secrets (staging publish profiles, one per region):
+#   AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING            (useast2 staging)
+#   AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING  (uscentral staging)
+# Fetch with:
+#   az functionapp deployment list-publishing-profiles --slot staging --xml \
+#     --subscription "TrackAbout CSP" --resource-group <rg> --name <app> \
+#     | gh secret set <SECRET_NAME>
+
 on:
   push:
     branches:
@@ -33,18 +52,18 @@ jobs:
       - name: Publish Function App
         run: dotnet publish ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }} --configuration Release --output ./publish
 
-      - name: Deploy to PRODUCTION
+      - name: Deploy to East US 2 staging slot
         uses: Azure/functions-action@v1.5.4
         with:
           app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
-          slot-name: PRODUCTION
-          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
+          slot-name: staging
+          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING }}
           package: ./publish
 
-      - name: Deploy to Central US PRODUCTION Slot
+      - name: Deploy to Central US staging slot
         uses: Azure/functions-action@v1.5.4
         with:
           app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME_CENTRALUS }}
-          slot-name: PRODUCTION
-          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS }}
+          slot-name: staging
+          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING }}
           package: ./publish

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -6,9 +6,9 @@ name: Build, Test, and Deploy to Azure Function App
 # for region-specific names and the exact swap commands.
 #
 # Required GitHub secrets:
-#   AZURE_FUNCTIONAPP_NAME, AZURE_FUNCTIONAPP_NAME_CENTRALUS
+#   AZURE_FUNCTIONAPP_NAME, AZURE_FUNCTIONAPP_NAME_2
 #   AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING            (region 1 staging slot)
-#   AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING  (region 2 staging slot)
+#   AZURE_FUNCTIONAPP_PUBLISH_PROFILE_2_STAGING  (region 2 staging slot)
 # Fetch a staging publish profile and set as a GH secret in one pipe:
 #   az functionapp deployment list-publishing-profiles --slot staging --xml \
 #     --subscription <SUB> --resource-group <RG> --name <APP> \
@@ -29,16 +29,16 @@ jobs:
     steps:
       - name: Verify required secrets are set
         env:
-          PROFILE_USEAST2: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING }}
-          PROFILE_CENTRALUS: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING }}
-          NAME_USEAST2: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
-          NAME_CENTRALUS: ${{ secrets.AZURE_FUNCTIONAPP_NAME_CENTRALUS }}
+          PROFILE_1: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING }}
+          PROFILE_2: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_2_STAGING }}
+          NAME_1: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
+          NAME_2: ${{ secrets.AZURE_FUNCTIONAPP_NAME_2 }}
         run: |
           missing=0
-          [ -z "$PROFILE_USEAST2" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING is not set"; missing=1; }
-          [ -z "$PROFILE_CENTRALUS" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING is not set"; missing=1; }
-          [ -z "$NAME_USEAST2" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_NAME is not set"; missing=1; }
-          [ -z "$NAME_CENTRALUS" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_NAME_CENTRALUS is not set"; missing=1; }
+          [ -z "$PROFILE_1" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING is not set"; missing=1; }
+          [ -z "$PROFILE_2" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_PUBLISH_PROFILE_2_STAGING is not set"; missing=1; }
+          [ -z "$NAME_1" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_NAME is not set"; missing=1; }
+          [ -z "$NAME_2" ] && { echo "::error::Secret AZURE_FUNCTIONAPP_NAME_2 is not set"; missing=1; }
           exit $missing
 
       - name: Checkout code
@@ -90,14 +90,14 @@ jobs:
       - name: Deploy to staging slot (region 2)
         uses: Azure/functions-action@v1.5.4
         with:
-          app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME_CENTRALUS }}
+          app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME_2 }}
           slot-name: staging
-          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING }}
+          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_2_STAGING }}
           package: ./publish
 
       - name: Health check staging slot (region 2)
         env:
-          APP_NAME: ${{ secrets.AZURE_FUNCTIONAPP_NAME_CENTRALUS }}
+          APP_NAME: ${{ secrets.AZURE_FUNCTIONAPP_NAME_2 }}
         run: |
           URL="https://${APP_NAME}-staging.azurewebsites.net/"
           echo "Polling staging slot for up to 180s..."

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Publish Function App
         run: dotnet publish ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }} --configuration Release --output ./publish
 
-      - name: Deploy to East US 2 staging slot
+      - name: Deploy to staging slot (region 1)
         uses: Azure/functions-action@v1.5.4
         with:
           app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
@@ -69,12 +69,12 @@ jobs:
           publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING }}
           package: ./publish
 
-      - name: Health check East US 2 staging slot
+      - name: Health check staging slot (region 1)
         env:
           APP_NAME: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
         run: |
           URL="https://${APP_NAME}-staging.azurewebsites.net/"
-          echo "Polling $URL for up to 180s..."
+          echo "Polling staging slot for up to 180s..."
           for i in $(seq 1 18); do
             code=$(curl -s -o /tmp/body -w "%{http_code}" --max-time 10 "$URL" || echo "000")
             if [ "$code" = "200" ] && grep -q "Functions" /tmp/body; then
@@ -84,10 +84,10 @@ jobs:
             echo "  attempt $i: code=$code"
             sleep 10
           done
-          echo "::error::East US 2 staging slot did not respond healthy within 180s"
+          echo "::error::Staging slot (region 1) did not respond healthy within 180s"
           exit 1
 
-      - name: Deploy to Central US staging slot
+      - name: Deploy to staging slot (region 2)
         uses: Azure/functions-action@v1.5.4
         with:
           app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME_CENTRALUS }}
@@ -95,12 +95,12 @@ jobs:
           publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING }}
           package: ./publish
 
-      - name: Health check Central US staging slot
+      - name: Health check staging slot (region 2)
         env:
           APP_NAME: ${{ secrets.AZURE_FUNCTIONAPP_NAME_CENTRALUS }}
         run: |
           URL="https://${APP_NAME}-staging.azurewebsites.net/"
-          echo "Polling $URL for up to 180s..."
+          echo "Polling staging slot for up to 180s..."
           for i in $(seq 1 18); do
             code=$(curl -s -o /tmp/body -w "%{http_code}" --max-time 10 "$URL" || echo "000")
             if [ "$code" = "200" ] && grep -q "Functions" /tmp/body; then
@@ -110,5 +110,5 @@ jobs:
             echo "  attempt $i: code=$code"
             sleep 10
           done
-          echo "::error::Central US staging slot did not respond healthy within 180s"
+          echo "::error::Staging slot (region 2) did not respond healthy within 180s"
           exit 1

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   AZURE_FUNCTIONAPP_PACKAGE_PATH: 'Azure.HyperScale.ElasticPool.AutoScaler'
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
 
 jobs:
   build-test-deploy:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   AZURE_FUNCTIONAPP_PACKAGE_PATH: 'Azure.HyperScale.ElasticPool.AutoScaler'
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
 
 jobs:
   build-and-test:

--- a/Azure.HyperScale.ElasticPool.AutoScaler.Tests/Azure.HyperScale.ElasticPool.AutoScaler.Tests.csproj
+++ b/Azure.HyperScale.ElasticPool.AutoScaler.Tests/Azure.HyperScale.ElasticPool.AutoScaler.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Azure.HyperScale.ElasticPool.AutoScaler/Azure.HyperScale.ElasticPool.AutoScaler.csproj
+++ b/Azure.HyperScale.ElasticPool.AutoScaler/Azure.HyperScale.ElasticPool.AutoScaler.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -15,7 +15,8 @@
     <PackageReference Include="azure.resourcemanager" Version="1.14.0" />
     <PackageReference Include="azure.resourcemanager.sql" Version="1.4.0" />
     <PackageReference Include="dapper" Version="2.1.79" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <!-- Range capped below 3.0.0: Microsoft has stated they will not bridge Worker.ApplicationInsights to WorkerService 3.x (OpenTelemetry-only). See azure-functions-dotnet-worker#3322. Migration to OTel tracked separately. -->
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="[2.23.0,3.0.0)" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />

--- a/Azure.HyperScale.ElasticPool.AutoScaler/Azure.HyperScale.ElasticPool.AutoScaler.csproj
+++ b/Azure.HyperScale.ElasticPool.AutoScaler/Azure.HyperScale.ElasticPool.AutoScaler.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="azure.resourcemanager" Version="1.14.0" />
     <PackageReference Include="azure.resourcemanager.sql" Version="1.4.0" />
     <PackageReference Include="dapper" Version="2.1.79" />
-    <!-- Range capped below 3.0.0: Microsoft has stated they will not bridge Worker.ApplicationInsights to WorkerService 3.x (OpenTelemetry-only). See azure-functions-dotnet-worker#3322. Migration to OTel tracked separately. -->
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="[2.23.0,3.0.0)" />
+    <!-- Pinned to exact 2.23.0. Microsoft will not bridge Worker.ApplicationInsights to WorkerService 3.x (OpenTelemetry-only). See azure-functions-dotnet-worker#3322. Migration to OTel tracked separately. Bump deliberately via PR, not via NuGet auto-resolve. -->
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />


### PR DESCRIPTION
## Why

.NET 8 reaches end-of-support on **November 10, 2026**. .NET 10 is the next LTS release, supported through **November 14, 2028**. This PR moves the codebase to net10.0 well ahead of EOL.

## What changed

- **Both csprojs**: `<TargetFramework>net8.0</TargetFramework>` → `net10.0`
- **Both GH Actions workflows** (`build-test.yml`, `build-test-deploy.yml`): `DOTNET_VERSION: '8.0.x'` → `'10.0.x'`
- **`build-test-deploy.yml`**: Deploys to a new `staging` slot on each Function App (instead of directly to production). Production rollout is a manual `az functionapp deployment slot swap` after staging validation — see the operator runbook for region-specific commands. Re-running the swap reverses it, providing rollback. The two original production-slot publish-profile secrets remain in GitHub Secrets as an emergency manual-redeploy path.
- **`build-test-deploy.yml`**: Preflight step that fails fast with a clear error if any required GitHub secret is unset, instead of an opaque "publish profile is empty" failure from `functions-action`.
- **`build-test-deploy.yml`**: Post-deploy `curl` health check against each staging slot — confirms the Functions host responded with HTTP 200 + the standard placeholder page within 180s. Catches "container won't start" / "broken zip" failure modes without needing additional auth.
- **`Microsoft.ApplicationInsights.WorkerService`** pinned to exact `2.23.0` with inline comment explaining why.

### About the WorkerService pin

Microsoft has stated in [azure-functions-dotnet-worker#3322](https://github.com/Azure/azure-functions-dotnet-worker/issues/3322) that they will **not** release a version of `Microsoft.Azure.Functions.Worker.ApplicationInsights` compatible with `WorkerService 3.x` — the 3.x line migrated to OpenTelemetry and dropped the `ITelemetryInitializer`/`ITelemetryProcessor` extensibility that the Functions worker bridge depends on. Their recommended path forward is OpenTelemetry, tracked as a separate longer-term project. The pin keeps us on 2.x; future bumps go through PR review rather than silent NuGet resolve.

## Out-of-band setup already completed

These are imperative Azure changes not visible in the diff but required for the workflow to deploy successfully:

- `staging` slot created on each prod Function App. Both empty, in `Running` state.
- `IsDryRun=true` set as a **slot-sticky** setting on both staging slots. This means the staging slot can fire its timer, query SQL, evaluate scaling decisions, and log "would scale to X" — but will not actually call ARM scale. Without this, both slots would race against production trying to scale the same elastic pools.
- New GH Actions secrets set, containing the staging-slot publish profiles fetched directly from Azure: `AZURE_FUNCTIONAPP_PUBLISH_PROFILE_STAGING` and `AZURE_FUNCTIONAPP_PUBLISH_PROFILE_CENTRALUS_STAGING`.

## Verification

- Local `dotnet build`: 0 warnings, 0 errors on .NET 10.0.107 SDK
- Local `dotnet test`: **74/74** xUnit tests pass on `net10.0`
- CI `Build and Test` workflow: green on this PR (42s, all steps passed on `ubuntu-latest`)

## Risk

Code-side risk is low: Worker SDK packages already met .NET 10 minimums, no `AsyncEnumerable` usage in the codebase, no ServiceBus triggers (so the auto-generated `WorkerExtensions.csproj` net8.0 hardcode is harmless here). Base image changes from Debian to Ubuntu for .NET 10 Linux containers — this project has no native deps and should be unaffected.

Deploy-mechanics risk is the bigger story, addressed by this PR's staging-slot + manual-swap + health-check pattern. After merge, the worst case is a broken .NET 10 build deployed to the staging slot of one or both regions; production keeps running .NET 8 until a human runs the swap command. The CI health check should catch the loudest failure modes before that swap is even an option.

## Test plan

- [x] CI passes on PR
- [ ] Merge → deploy workflow runs on `main` push
- [ ] Preflight secret check passes (all four secrets present)
- [ ] Both regions deploy to their respective staging slots
- [ ] Both health checks return HTTP 200 + Functions placeholder within 180s
- [ ] Tail logs on each staging slot: clean host start, first timer fires, SQL query succeeds, ≥1 scaling evaluation logged (decision logged; ARM call skipped due to dry-run)
- [ ] Swap region 1 to production (see operator runbook for command)
- [ ] 24h production soak
- [ ] Swap region 2 to production if region 1 clean
- [ ] Rollback path (if needed): re-run the same swap command — it reverses the previous swap

## Follow-ups (filed in local notes, not in this PR)

- Pin GH Actions to commit SHAs + dependabot rule (currently floating `@v5` tags)
- Wrap deploy job in GitHub `environment:` with required reviewer
- Migrate to OIDC (`azure/login@v2`) and retire publish-profile auth
- Add `packages.lock.json` with `--locked-mode` for fully reproducible restores
- Audit slot-sticky settings on all sensitive App Settings on both Function Apps