### PR TITLE
fix: pin Azure/functions-action to a verified commit SHA (supply-chain hardening)

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -62,7 +62,7 @@ jobs:
         run: dotnet publish ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }} --configuration Release --output ./publish
 
       - name: Deploy to staging slot (region 1)
-        uses: Azure/functions-action@v1.5.4
+        uses: Azure/functions-action@bc63708cc6539760eea18d8a7de4ce8ef5fdf593 # v1.5.6
         with:
           app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME }}
           slot-name: staging
@@ -88,7 +88,7 @@ jobs:
           exit 1
 
       - name: Deploy to staging slot (region 2)
-        uses: Azure/functions-action@v1.5.4
+        uses: Azure/functions-action@bc63708cc6539760eea18d8a7de4ce8ef5fdf593 # v1.5.6
         with:
           app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME_2 }}
           slot-name: staging


### PR DESCRIPTION
## Why

On June 5, 2026, GitHub disabled `Azure/functions-action` (and 72 other Microsoft repos) during the Miasma supply-chain incident. Our workflow referenced the action by mutable tag (`@v1.5.4`). A Git tag is a movable pointer: whoever controls the action repo can repoint a tag at malicious code without our workflow file changing. That is the exact mechanism behind the March 2025 `tj-actions/changed-files` compromise (CVE-2025-30066). A commit SHA cannot be moved.

## What changed

Pinned `Azure/functions-action` to commit `bc63708cc6539760eea18d8a7de4ce8ef5fdf593`, which is the `v1.5.6` release (published 2026-04-14, before the incident). Verified: both the `v1` and `v1.5.6` tags in the restored repo resolve to this commit, and it matches the SHA recommended in the official incident thread (Azure/functions-action#363).

**Note: this also bumps the action version from v1.5.4 to v1.5.6** (two patch releases). Low risk, but flagging it since it is a version change, not just a pin.

Files updated:
- `.github/workflows/build-test-deploy.yml` (2 occurrences)

## Risk / context

Run history shows this repo last deployed on 2026-05-19, before the incident, and not since, so there is no indication of exposure. This is preventive hardening. Going forward, Dependabot can keep this SHA current with reviewable PRs.
